### PR TITLE
Add todo to track work to generate `meta`

### DIFF
--- a/todo.org
+++ b/todo.org
@@ -2,3 +2,4 @@
 - [ ] Always use the latest version except when there's a version specified in the egg-list
 - [X] Support reading the egg-list from stdin
 - [ ] Generate default.nix for non-egg CHICKEN apps
+- [ ] Generate `meta` sets containing e.g. `description`, `homepage`, and `license`


### PR DESCRIPTION
Got this idea after reading this nixpkgs pull request: https://github.com/NixOS/nixpkgs/pull/201909#event-7850121922

> Eventually it'd be great if egg2nix could generate meta sets containing,
> e.g. description , homepage and license. This would also ensure that
> meta.position is resolved correctly which allows jumping to the package
> definition.

Happy to have a go at this work once I get a better understanding of the implementation details.